### PR TITLE
add masonry layout as progressive enhancement

### DIFF
--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -129,23 +129,23 @@ import Layout from '../layouts/Layout.astro';
 			grid-row: 2/ span 2;
 		}
 
-		section img:nth-of-type(4) {
+		section img[src$="verbouwen-amsterdam.jpg"] {
 			grid-column: 1;
 			grid-row: 3/ span 2;
 		}
-		section img:nth-of-type(5) {
+		section img[src$="man-met-krant-madrid.jpg"] {
 			grid-row: 3;
 			grid-column: 2;
 		}
-		section img:nth-of-type(6) {
+		section img[src$="japan_paal.jpg"] {
 			grid-row: 4/ span 2;
 			grid-column: 3;
 		}
-		section img:nth-of-type(7) {
+		section img[src$="moto-casablance.jpg"] {
 			grid-row: 4;
 			grid-column: 2;
 		}
-		section img:nth-of-type(8) {
+		section img[src$="klaprozen-qazvin.jpg"] {
 			grid-row: 5;
 			grid-column: 2;
 		}	
@@ -163,10 +163,10 @@ import Layout from '../layouts/Layout.astro';
 		aspect-ratio: 1719/2560;
 	}
 
-	section img:nth-of-type(4) {
+	section img[src$="verbouwen-amsterdam.jpg"] {
 		aspect-ratio: 1575/2554;
 	}
-	section img:nth-of-type(5) {
+	section img[src$="man-met-krant-madrid.jpg"] {
 		aspect-ratio: 2560/1709;
 	}
 </style>

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -117,30 +117,25 @@ import Layout from '../layouts/Layout.astro';
 			grid-column: 1/ span 2;
 			grid-row: 1/ span 2;
 			align-self: center;
-			aspect-ratio: 2560/1698;
 		}
 
 		section img:nth-of-type(2) {
 			grid-column: 3;
 			grid-row: 1;
-			aspect-ratio: 2560/1698;
 		}
 
 		section img:nth-of-type(3) {
 			grid-column: 3;
 			grid-row: 2/ span 2;
-			aspect-ratio: 1719/2560;
 		}
 
 		section img:nth-of-type(4) {
 			grid-column: 1;
 			grid-row: 3/ span 2;
-			aspect-ratio: 1575/2554;
 		}
 		section img:nth-of-type(5) {
 			grid-row: 3;
 			grid-column: 2;
-			aspect-ratio: 2560/1709;
 		}
 		section img:nth-of-type(6) {
 			grid-row: 4/ span 2;

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -113,18 +113,18 @@ import Layout from '../layouts/Layout.astro';
 	}
 
 	@supports not (grid-template-rows: masonry) {
-		section img:nth-of-type(1) {
+		section img[src$="japan_bus.jpg"]  {
 			grid-column: 1/ span 2;
 			grid-row: 1/ span 2;
 			align-self: center;
 		}
 
-		section img:nth-of-type(2) {
+		section img[src$="japan_poort.jpg"] {
 			grid-column: 3;
 			grid-row: 1;
 		}
 
-		section img:nth-of-type(3) {
+		section img[src$="goudsmid-zurich.jpg"] {
 			grid-column: 3;
 			grid-row: 2/ span 2;
 		}
@@ -151,15 +151,15 @@ import Layout from '../layouts/Layout.astro';
 		}	
 	}
 
-	section img:nth-of-type(1) {
+	section img[src$="japan_bus.jpg"] {
 		aspect-ratio: 2560/1698;
 	}
 
-	section img:nth-of-type(2) {
+	section img[src$="japan_poort.jpg"]  {
 		aspect-ratio: 2560/1698;
 	}
 
-	section img:nth-of-type(3) {
+	section img[src$="goudsmid-zurich.jpg"] {
 		aspect-ratio: 1719/2560;
 	}
 

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -105,45 +105,73 @@ import Layout from '../layouts/Layout.astro';
 		width: 100%;
 	}
 
+	@supports (grid-template-rows: masonry) {
+		section {
+			grid-template-columns: 1fr 1.683fr 1fr;
+			grid-template-rows: masonry;
+		}
+	}
+
+	@supports not (grid-template-rows: masonry) {
+		section img:nth-of-type(1) {
+			grid-column: 1/ span 2;
+			grid-row: 1/ span 2;
+			align-self: center;
+			aspect-ratio: 2560/1698;
+		}
+
+		section img:nth-of-type(2) {
+			grid-column: 3;
+			grid-row: 1;
+			aspect-ratio: 2560/1698;
+		}
+
+		section img:nth-of-type(3) {
+			grid-column: 3;
+			grid-row: 2/ span 2;
+			aspect-ratio: 1719/2560;
+		}
+
+		section img:nth-of-type(4) {
+			grid-column: 1;
+			grid-row: 3/ span 2;
+			aspect-ratio: 1575/2554;
+		}
+		section img:nth-of-type(5) {
+			grid-row: 3;
+			grid-column: 2;
+			aspect-ratio: 2560/1709;
+		}
+		section img:nth-of-type(6) {
+			grid-row: 4/ span 2;
+			grid-column: 3;
+		}
+		section img:nth-of-type(7) {
+			grid-row: 4;
+			grid-column: 2;
+		}
+		section img:nth-of-type(8) {
+			grid-row: 5;
+			grid-column: 2;
+		}	
+	}
+
 	section img:nth-of-type(1) {
-		grid-column: 1/ span 2;
-    	grid-row: 1/ span 2;
-		align-self: center;
 		aspect-ratio: 2560/1698;
 	}
 
 	section img:nth-of-type(2) {
-		grid-column: 3;
-    	grid-row: 1;
 		aspect-ratio: 2560/1698;
 	}
 
 	section img:nth-of-type(3) {
-		grid-column: 3;
-    	grid-row: 2/ span 2;
 		aspect-ratio: 1719/2560;
 	}
 
 	section img:nth-of-type(4) {
-		grid-column: 1;
-    	grid-row: 3/ span 2;
 		aspect-ratio: 1575/2554;
 	}
 	section img:nth-of-type(5) {
-		grid-row: 3;
-    	grid-column: 2;
 		aspect-ratio: 2560/1709;
-	}
-	section img:nth-of-type(6) {
-		grid-row: 4/ span 2;
-    	grid-column: 3;
-	}
-	section img:nth-of-type(7) {
-		grid-row: 4;
-    	grid-column: 2;
-	}
-	section img:nth-of-type(8) {
-		grid-row: 5;
-    	grid-column: 2;
 	}
 </style>

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -14,10 +14,10 @@ import Layout from '../layouts/Layout.astro';
 			</div>
 		</nav>
 		<section>
+			<img src="/portofolio/assets/verbouwen-amsterdam.jpg" alt="" loading="lazy">
 			<img src="/portofolio/assets/japan_bus.jpg" loading="eager">
 			<img src="/portofolio/assets/japan_poort.jpg" loading="eager">
 			<img src="/portofolio/assets/goudsmid-zurich.jpg" loading="eager" alt="">
-			<img src="/portofolio/assets/verbouwen-amsterdam.jpg" alt="" loading="lazy">
 			<img src="/portofolio/assets/man-met-krant-madrid.jpg" alt="" loading="lazy">
 			<img src="/portofolio/assets/japan_paal.jpg" alt="" loading="lazy">
 			<img src="/portofolio/assets/motor-casablanca.jpg" alt="" loading="lazy">


### PR DESCRIPTION
This PR will change home page to use a masonry layout. It ships it as a progressive enhancement.

**Masonry**
![image](https://github.com/Schrder/portofolio/assets/10298837/fa2aae1e-f386-40bf-8af1-7ea84da6b652)

**Current implementation**
<img width="1623" alt="image" src="https://github.com/Schrder/portofolio/assets/10298837/3920d9c2-ef82-4157-bf3b-be4ce028ec2a">


This looks a lot better and I feel this is much more suited for what we are trying to accomplish. The downside is that browser support is currently zero to none. Only safari TP supports it, with no real timeline of landing into safari any time soon.
